### PR TITLE
DropDownText: Set tooltip_text for each row

### DIFF
--- a/lib/DropDownText.vala
+++ b/lib/DropDownText.vala
@@ -91,6 +91,18 @@ public sealed class Ryokucha.DropDownText : Gtk.Grid {
             label.label = item.text;
             bind_property ("max-width-chars", label, "max-width-chars", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE);
             bind_property ("ellipsize", label, "ellipsize", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE);
+            bind_property ("ellipsize", label, "tooltip_text", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE,
+                           (binding, from_value, ref to_value) => {
+                               Pango.EllipsizeMode ellipsize_mode = (Pango.EllipsizeMode) from_value;
+                               // Set the label text to tooltip_text if ellipsized, otherwise clear it
+                               if (ellipsize_mode != Pango.EllipsizeMode.NONE) {
+                                   to_value.set_string (label.label);
+                               } else {
+                                   to_value.set_string (null);
+                               }
+
+                               return true;
+                           });
         });
 
         dropdown = new Gtk.DropDown (liststore, null) {


### PR DESCRIPTION
Although you can set tooltip_text for DropDownText itself already because it inherits Gtk.Widget, users may not notice that as reported at https://github.com/ryonakano/reco/issues/224:

> Thanks for the great app!
> Just a concern though, I'm unable to view the microphone names in the app window.
>
> I think you could either let user be able to resize the app window.
> Or you could show the full name as a tooltip while hovering over it.