### PR TITLE
fix: DropDownText: Correct item label alignment

### DIFF
--- a/lib/DropDownText.vala
+++ b/lib/DropDownText.vala
@@ -77,7 +77,9 @@ public sealed class Ryokucha.DropDownText : Gtk.Widget {
         }
 
         construct {
-            label = new Gtk.Label (null);
+            label = new Gtk.Label (null) {
+                halign = Gtk.Align.START
+            };
 
             label.set_parent (this);
         }


### PR DESCRIPTION
Fix a regression of #4 that the label of each item in the drop down no longer left-aligned.